### PR TITLE
fix input div not moving with canvas

### DIFF
--- a/src/canvas/canvas.js
+++ b/src/canvas/canvas.js
@@ -510,8 +510,8 @@
         _getElementXY: function (e) {
             var x = 0, y = 0;
             while (e) {
-                x += e.offsetLeft;
-                y += e.offsetTop;
+                x += (e.offsetLeft-e.scrollLeft);
+                y += (e.offsetTop-e.scrollTop);
                 e = e.offsetParent;
             }
             return {x: x, y: y};


### PR DESCRIPTION
fix input div not moving with canvas when running on single page webapp such as angular.
scrollTop is the scroll distance on coordinate-y and the other is on coordinate-x