### PR TITLE
Ortho and Perspective camera projections now properly conform to viewport boundary sizes.

### DIFF
--- a/src/camera/ortho.js
+++ b/src/camera/ortho.js
@@ -57,20 +57,24 @@
 
         _update: function () {
 
+            const WIDTH_INDEX = 2;
+            const HEIGHT_INDEX = 3;
+
             var scene = this.scene;
             var scale = this._scale;
-            var canvas = scene.canvas.canvas;
-            var canvasWidth = canvas.clientWidth;
-            var canvasHeight = canvas.clientHeight;
             var halfSize = 0.5 * scale;
-            var aspect = canvasWidth / canvasHeight;
+
+            var boundary = scene.viewport.boundary;
+            var boundaryWidth = boundary[WIDTH_INDEX];
+            var boundaryHeight = boundary[HEIGHT_INDEX];
+            var aspect = boundaryWidth / boundaryHeight;
 
             var left;
             var right;
             var top;
             var bottom;
 
-            if (canvasWidth > canvasHeight) {
+            if (boundaryWidth > boundaryHeight) {
                 left = -halfSize;
                 right = halfSize;
                 top = halfSize / aspect;

--- a/src/camera/perspective.js
+++ b/src/camera/perspective.js
@@ -59,8 +59,11 @@
 
         _update: function () {
 
-            var canvas = this.scene.canvas.canvas;
-            var aspect = canvas.clientWidth / canvas.clientHeight;
+            const WIDTH_INDEX = 2;
+            const HEIGHT_INDEX = 3;
+
+            var boundary = this.scene.viewport.boundary;
+            var aspect = boundary[WIDTH_INDEX] / boundary[HEIGHT_INDEX];
 
             var fov = this._fov;
             var fovAxis = this._fovAxis;


### PR DESCRIPTION
This change allows users to create viewports of size different than that of the canvas without having to manually update camera projection matrices.