### PR TITLE
Derivatives hint fix

### DIFF
--- a/src/canvas/canvas.js
+++ b/src/canvas/canvas.js
@@ -501,9 +501,12 @@
             }
 
             if (this.gl) {
-                if (xeogl.WEBGL_INFO.SUPPORTED_EXTENSIONS["OES_standard_derivatives"]) { // For normal mapping
-                    this.gl.getExtension("OES_standard_derivatives");
-                    //  this.gl.hint(this.gl.FRAGMENT_SHADER_DERIVATIVE_HINT_OES, this.gl.FASTEST)
+                // Setup extension (if necessary) and hints for fragment shader derivative functions
+                if (this.webgl2) {
+                    this.gl.hint(this.gl.FRAGMENT_SHADER_DERIVATIVE_HINT, this.gl.FASTEST);
+                } else if (xeogl.WEBGL_INFO.SUPPORTED_EXTENSIONS["OES_standard_derivatives"]) {
+                    var ext = this.gl.getExtension("OES_standard_derivatives");
+                    this.gl.hint(ext.FRAGMENT_SHADER_DERIVATIVE_HINT_OES, this.gl.FASTEST);
                 }
             }
         },


### PR DESCRIPTION
This sets the FRAGMENT_SHADER_DERIVATIVE_HINT hint correctly for both webgl1 and webgl2.