### PR TITLE
Provide a three-digit semantic version number to keep npm happy.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "xeogl",
   "title": "xeogl",
-  "version": "0.8",
+  "version": "0.8.0",
   "description": "A WebGL-based 3D visualization engine from xeoLabs",
   "homepage": "http://xeogl.org/",
   "author": {


### PR DESCRIPTION
I couldn't get npm to build without this change. Seems to require a three-digit semantic version.