### PR TITLE
Fixed buildEdgesIndices on large meshes.

### DIFF
--- a/src/geometry/geometry.js
+++ b/src/geometry/geometry.js
@@ -1081,13 +1081,13 @@
                         continue;
                     }
                 }
-                ia = edge.index1;
-                ib = edge.index2;
+                ia = indicesReverseLookup[edge.index1];
+                ib = indicesReverseLookup[edge.index2];
                 if (!largeIndex && ia > 65535 || ib > 65535) {
                     largeIndex = true;
                 }
-                edgeIndices.push(indicesReverseLookup[ia]);
-                edgeIndices.push(indicesReverseLookup[ib]);
+                edgeIndices.push(ia);
+                edgeIndices.push(ib);
             }
             return (largeIndex || combined) ? new Uint32Array(edgeIndices) : new Uint16Array(edgeIndices);
         }


### PR DESCRIPTION
The check for large indices was being done under the wrong indices, so it was possible for

`ia <= 65535` while `edgeIndices[indicesReverseLookup[ia]] > 65535`.

This caused Uint16Array to not be able to represent the desired edgeIndices (due to the two byte limitation) and for the edges to show incorrectly.

Fixes #274