### PR TITLE
fix: solve canvas2image.js wrong, make image's size correct

### DIFF
--- a/src/libs/canvas2image.js
+++ b/src/libs/canvas2image.js
@@ -151,7 +151,7 @@ const Canvas2Image = (function () {
 
             const oSaveCtx = oSaveCanvas.getContext("2d");
 
-            oSaveCtx.drawImage(oCanvas, 0, 0, oCanvas.width, oCanvas.height, 0, 0, iWidth, iWidth);
+            oSaveCtx.drawImage(oCanvas, 0, 0, oCanvas.width, oCanvas.height, 0, 0, iWidth, iHeight);
 
             return oSaveCanvas;
         }


### PR DESCRIPTION
The img's height is incorrect, and I find line 154 have 2 iwidth in canvas2image.js. and I have fixed this problem.