### PR TITLE
getAABB min and max comparison values

### DIFF
--- a/src/scene/scene.js
+++ b/src/scene/scene.js
@@ -2166,12 +2166,12 @@ class Scene extends Component {
         if (target.length === 0) {
             return this.aabb;
         }
-        let xmin = 100000;
-        let ymin = 100000;
-        let zmin = 100000;
-        let xmax = -100000;
-        let ymax = -100000;
-        let zmax = -100000;
+        let xmin = math.MAX_DOUBLE;
+        let ymin = math.MAX_DOUBLE;
+        let zmin = math.MAX_DOUBLE;
+        let xmax = -math.MAX_DOUBLE;
+        let ymax = -math.MAX_DOUBLE;
+        let zmax = -math.MAX_DOUBLE;
         let valid;
         this.withObjects(target, object => {
                 const aabb = object.aabb;


### PR DESCRIPTION
values for comparing min and max values need to set to a maxium available value not 10000, as it is in get function of aabb as it leads to errors when using large scale models with larger values than 10000