### PR TITLE
zoom on empty canvas leads to infinity zoomRate

### DIFF
--- a/src/controls/cameraControl.js
+++ b/src/controls/cameraControl.js
@@ -845,7 +845,11 @@ class CameraControl extends Component {
                 const zsize = aabb[5] - aabb[2];
                 let max = (xsize > ysize ? xsize : ysize);
                 max = (zsize > max ? zsize : max);
-                return max / 30;
+                if (isFinite(max)){
+                    return max / 30;
+                } else {
+                    return 0;
+                }
             }
 
             document.addEventListener("keyDown", function (e) {


### PR DESCRIPTION
In an initial setup with an emtpy canvas, using the mousewheel to scroll leads to infinity values while calculating the zoomRate using the scenes aabb. 
A solution would be returning a zoomRate of 0, if theres is nothing loaded into the scene. 
Another approach would be to calculate the aabb of all loaded models in the scene not using the scenes aabb by itself.