### PR TITLE
fixes bug if obj file does not specify a mtllib

### DIFF
--- a/examples/js/models/OBJModel.js
+++ b/examples/js/models/OBJModel.js
@@ -700,6 +700,9 @@
         var basePath = state.basePath;
         var srcList = Object.keys(state.materialLibraries);
         var numToLoad = srcList.length;
+        if (numToLoad === 0) {
+            ok();
+        }
         for (var i = 0, len = numToLoad; i < len; i++) {
             loadMTL(model, basePath, basePath + srcList[i], function () {
                 if (--numToLoad === 0) {


### PR DESCRIPTION
if the obj file does not provide a mtllib the callback function is never reached because no materialLibraries are provided, so the model will never be created and the spinner spins indefinetly